### PR TITLE
#20 buildTag and buildId are now separate. Refactored the naming for …

### DIFF
--- a/src/main/groovy/com/redpillanalytics/analytics/AnalyticsPlugin.groovy
+++ b/src/main/groovy/com/redpillanalytics/analytics/AnalyticsPlugin.groovy
@@ -181,20 +181,22 @@ class AnalyticsPlugin implements Plugin<Project> {
             group 'analytics'
             description "Analytics workflow task for producing data to all configured sinks."
 
-            if (project.analytics.compressFiles.toBoolean()) {
+            mustRunAfter project.build
+
+            if (project.analytics.compressFiles) {
 
                log.debug "Analytics files will be compressed after production."
 
                from "${project.analytics.getAnalyticsDir(project.buildDir).parent}/"
 
-               appendix 'analytics'
-               version CI.getTimestamp()
+               baseName 'analytics'
+               appendix project.extensions.analytics.buildId
 
             }
 
             doLast {
 
-               if (project.analytics.cleanFiles.toBoolean()) {
+               if (project.analytics.cleanFiles) {
 
                   log.debug "Analytics files will be deleted after production."
 

--- a/src/main/groovy/com/redpillanalytics/analytics/AnalyticsPluginExtension.groovy
+++ b/src/main/groovy/com/redpillanalytics/analytics/AnalyticsPluginExtension.groovy
@@ -23,6 +23,12 @@ class AnalyticsPluginExtension {
     */
    String buildId = CI.getTimestamp()
    /**
+    * A unique ID for each CI Server build, which might encompass multiple Gradle executions.
+    * <p>
+    * The default value is the build tag from known CI servers, and if none are detected, then it uses {@link #buildId}.
+    */
+   String buildTag = CI.getBuildTagNull() ?: buildId
+   /**
     * The name to use for the {@code task} JSON data file.
     */
    String tasksFileName = 'task.json'
@@ -132,6 +138,7 @@ class AnalyticsPluginExtension {
 
       return [
               buildid      : buildId,
+              buildTag     : buildTag,
               organization : organization,
               hostname     : hostname,
               commithash   : gitCommitHash,

--- a/src/main/groovy/com/redpillanalytics/common/CI.groovy
+++ b/src/main/groovy/com/redpillanalytics/common/CI.groovy
@@ -26,6 +26,12 @@ class CI {
 
    }
 
+   static getBuildTagNull() {
+
+      return System.getenv('BUILD_TAG') ?: System.getenv('bamboo_buildResultKey') ?: null
+
+   }
+
    static getBuildTag() {
 
       return System.getenv('BUILD_TAG') ?: System.getenv('bamboo_buildResultKey') ?: getTimestamp()


### PR DESCRIPTION
…the analytics distribution file.